### PR TITLE
Add consolidated setup blueprint and document task conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,9 @@
 - Document the current understanding and key explanations from the AI development journey.
 - Focus on insights, commands, and verification steps rather than upcoming tasks.
 - Maintain a table of contents that links to the major sections.
+- Treat the "End-to-End Setup Blueprint" chapter as the stylistic reference for future additions; new chapters should match its concise, action-oriented tone and structure.
 
 ### next-steps.md
 - Record actionable next steps for the overall repository.
 - Keep entries current and remove items once completed or no longer relevant.
+- Mark completed items using Markdown strikethrough (e.g., `~~Task~~`). Items 1–3 are already completed and should remain crossed out.

--- a/ai-notes.md
+++ b/ai-notes.md
@@ -12,6 +12,7 @@ This document summarizes the key concepts and steps taken to set up a local AI d
 7. [TorchVision and TorchAudio](#7-torchvision-and-torchaudio)
 8. [Notes on Nightly Builds](#8-notes-on-nightly-builds)
 9. [Summary of Key Learnings](#9-summary-of-key-learnings)
+10. [End-to-End Setup Blueprint](#10-end-to-end-setup-blueprint)
 
 ---
 
@@ -219,6 +220,22 @@ pip install torch torchvision torchaudio --index-url https://download.pytorch.or
 | **Nightly Builds** | Developer builds with cutting-edge features |
 | **SM (Streaming Multiprocessor)** | GPU architecture version identifier |
 | **torchvision / torchaudio** | PyTorch extensions for image and audio processing |
+
+---
+
+## 10. End-to-End Setup Blueprint
+
+This chapter condenses the essential actions from Sections 1–9 into a practical workflow that can be followed from a clean system to a validated GPU-enabled PyTorch environment.
+
+1. **Prepare the workspace** by creating a project directory and activating a Python virtual environment to isolate dependencies and guarantee reproducibility.
+2. **Upgrade foundational packaging tools** (`pip`, `setuptools`, and `wheel`) to ensure compatibility with the latest binary distributions and to speed up installations.
+3. **Install PyTorch with matching CUDA support**, optionally selecting the nightly channel when targeting cutting-edge GPUs or driver/toolkit combinations.
+4. **Verify CUDA and driver alignment** by checking GPU architecture support tables, confirming the installed CUDA toolkit, and reviewing driver status with `nvidia-smi`.
+5. **Run GPU functionality tests** in PyTorch to confirm device discovery, architecture availability, and successful execution of tensor operations on the GPU.
+6. **Validate auxiliary libraries** such as TorchVision and TorchAudio to ensure that vision and audio tooling versions align with the installed PyTorch build.
+7. **Document key learnings**—including SM mappings, packaging utilities, and nightly build considerations—to retain institutional knowledge for future setup iterations.
+
+Use this blueprint whenever you need a succinct, end-to-end reminder of the environment setup process; each bullet links conceptually back to the detailed chapters above.
 
 ---
 

--- a/next-steps.md
+++ b/next-steps.md
@@ -1,8 +1,8 @@
 # Next Steps
 
-1. Initialize a GitHub repository for `ai-lab`.
-2. Add `.venv` to `.gitignore`.
-3. Commit the current documentation and test scripts.
+1. ~~Initialize a GitHub repository for `ai-lab`.~~
+2. ~~Add `.venv` to `.gitignore`.~~
+3. ~~Commit the current documentation and test scripts.~~
 4. Install Hugging Face tooling:
    ```bash
    pip install transformers datasets accelerate


### PR DESCRIPTION
## Summary
- add an "End-to-End Setup Blueprint" chapter that consolidates the key actions from sections 1–9 of the notes
- document in `AGENTS.md` that the new chapter defines the stylistic example for future notes and note the strikethrough convention for completed next steps
- mark the first three items in `next-steps.md` as completed using the documented strikethrough format

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1445e8c1c8333b8b12d71d23b05fc