### PR TITLE
Document Hugging Face Hub API workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,7 @@
 
 - **Language:** All repository content, including documentation, code comments, commit messages, and configuration entries, must be written in English. Do not use emojis unless explicitly requested.
 - **Scope:** These guidelines apply to the entire repository unless superseded by a more specific `AGENTS.md` in a subdirectory.
+- **Cheatsheet summaries:** When documenting APIs, database queries, libraries, or notable function groups, include cheat sheet-style summaries of the essential filters or functions relevant to the immediate use case whenever it adds clarity.
 
 ## File-Specific Expectations
 


### PR DESCRIPTION
## Summary
- add a repository-wide guideline encouraging cheat sheet-style summaries when documenting APIs and related tooling
- document a new "The Hub API" subchapter in `ai-notes.md` with setup steps, a Hub API cheatsheet, model search examples, metadata inspection, and task discovery workflows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4addab0f08333b80c05d87c3e3ac7