### PR TITLE
Add speech recognition guidance and model overviews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - **Cheatsheet summaries:** When documenting APIs, database queries, libraries, or notable function groups, include cheat sheet-style summaries of the essential filters or functions relevant to the immediate use case whenever it adds clarity.
 - **Flowcharts:** Use flowcharts whenever they clarify multi-step processes. Arrange steps from left to right when space allows; otherwise, stack steps vertically. Always enclose each step in a bordered container so the chart reads visually as a flow diagram. Render flowcharts as ASCII art and center the text inside each node for consistent readability.
 - **`ai-projects_backlog.md`:** Keep all backlog entries in English, structuring each project with a clear vision, strategy, and prioritized tasks.
+- **Working with Hugging Face topics:** For every topic documented under the "Working with Hugging Face" chapter in `ai-notes.md`, verify whether specialized and widely adopted Hugging Face models exist for the topic's primary use cases. When they do, append a concise overview to the chapter that lists each model with its core use case, strengths, and limitations.
 
 ## File-Specific Expectations
 


### PR DESCRIPTION
## Summary
- extend the repository guidance so every Hugging Face topic captures widely adopted models with use-case notes
- update the Hugging Face table of contents to include model landscape overviews for each topic
- document model overviews for text classification, summarization, document QA, computer vision, and add a full speech recognition and audio generation chapter with workflow example

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5f46f0c6c83339d22fad248492c2c